### PR TITLE
Fix x264 commit id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ x264/config.mak: x264/configure
 	cd $(@D) && CC=$(CC) CPPFLAGS= CFLAGS= ./configure --extra-cflags=-march=$(ARCH)
 x264/configure: x264/.git/config $(WORKBENCH_BASE)/Makefile
 	cd $(@D) && git diff --name-status --exit-code
-	cd $(@D) && git reset --hard aff928d2a2f601072cebecfd1ac5ff768880cf88
+	cd $(@D) && git reset --hard b7a50c16414631c8ff5e417da51b190c8999027e
 	cd $(@D) && git clean -dfx
 	touch $@
 x264/.git/config:


### PR DESCRIPTION
Although the old seemed to be valid at some point [0], checkout failed with
'fatal: Could not parse object 'aff928d2a2f601072cebecfd1ac5ff768880cf88'. The
corresponding commit seems to be [1] and checkout works. The current master
does not work, because it is incompatible with the version of libav used
(undefined reference to 'x264_encoder_open_142').

[0] http://git.videolan.org/?p=x264.git;a=commit;h=aff928d2a2f601072cebecfd1ac5ff768880cf88
[1] http://git.videolan.org/?p=x264.git;a=commit;h=b7a50c16414631c8ff5e417da51
